### PR TITLE
ci: use shared PR checker workflow

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,4 +1,5 @@
 name: pr-checker
+
 on:
   pull_request_target:
     types:
@@ -7,15 +8,7 @@ on:
 
 jobs:
   pr-checker:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    steps:
-      - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # v1.4.3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pass_on_octokit_error: false
-          github_configuration_owner: gainsway
-          github_configuration_repo: .github
-          github_configuration_path: .github/pr-title-checker-config.json
+    uses: gainsway/github-workflows/.github/workflows/job.pr-checker.yml@d9014b92c7b874bd23e83be096f96c4582d0958e


### PR DESCRIPTION
Replaces the duplicated PR checker implementation with the reusable organization workflow from `gainsway/github-workflows`, pinned to commit `d9014b92c7b874bd23e83be096f96c4582d0958e`.

The existing trigger and permissions are preserved.