### PR TITLE
ci: use main shared PR checker workflow 

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -11,4 +11,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: gainsway/github-workflows/.github/workflows/job.pr-checker.yml@d9014b92c7b874bd23e83be096f96c4582d0958e
+    uses: gainsway/github-workflows/.github/workflows/job.pr-checker.yml@main


### PR DESCRIPTION
## What changed

Updates the reusable PR checker reference from the pinned commit to `gainsway/github-workflows/.github/workflows/job.pr-checker.yml@main`.

## Why

GitHub cannot resolve the reusable workflow at the pinned commit, causing PR checker runs to fail before creating jobs.